### PR TITLE
Retransmission Scheduler

### DIFF
--- a/client.py
+++ b/client.py
@@ -29,6 +29,16 @@ class Inflight:
     ts_last_ms: int #time of last send
     retries: int = 0
 
+#global runtime state
+inflight: dict[int, Inflight] = {} #seq num: packet data
+srtts_ms: float | None = None #smooth rtt - estimate
+rttvar_ms: float | None = None #variation in RTT
+RTO_min_ms = 100 #lowerbound RTO
+RTO_max_ms = 3000 #upperbound RTO
+MAX_RETRIES = 5
+next_seq = 0 #increments 1 each send
+
+
 ALPN = "game/1"
 RELIABLE_CHANNEL = 0  # Used for Stream Data (Critical State)
 UNRELIABLE_CHANNEL = 1  # Used for Datagrams (Movement)

--- a/client.py
+++ b/client.py
@@ -4,6 +4,7 @@ import random
 import time
 from typing import Optional, Dict
 from metrics import RollingStats, Jitter
+from dataclasses import dataclass, field
 
 try:
     import uvloop
@@ -19,6 +20,14 @@ from aioquic.quic.events import (
     StreamDataReceived,
     HandshakeCompleted,
 )
+
+@dataclass
+class Inflight:
+    payload_bytes: bytes
+    seq: int
+    ts_first_ms: int #time of first send
+    ts_last_ms: int #time of last send
+    retries: int = 0
 
 ALPN = "game/1"
 RELIABLE_CHANNEL = 0  # Used for Stream Data (Critical State)

--- a/client.py
+++ b/client.py
@@ -223,13 +223,16 @@ class GameClientProtocol:
 
         recv_task = asyncio.create_task(self._recv_loop())
         # Part f Randomized sending loop
-        mixed_task = asyncio.create_task(self._mixed_loop(reliable_hz=5, unreliable_hz=30)) 
+        mixed_task = asyncio.create_task(self._mixed_loop(reliable_hz=5, unreliable_hz=30))
+        self._retransmit_task = asyncio.create_task(self.retransmit_scheduler())
 
         await asyncio.sleep(10)  
         recv_task.cancel()
         mixed_task.cancel()
         if self._metrics_task:
             self._metrics_task.cancel()
+        if self._retransmit_task:
+            self._retransmit_task.cancel()
         
         self.quic.close()
         self.endpoint.transmit()

--- a/client.py
+++ b/client.py
@@ -213,8 +213,6 @@ class GameClientProtocol:
         except asyncio.CancelledError:
             pass
 
-
-    
     async def run(self):
         # Initial reliable hello for connection setup
         if self.ctrl_stream_id is None:

--- a/client.py
+++ b/client.py
@@ -105,8 +105,6 @@ class GameClientProtocol:
            #update rtt est
             self.srtt_ms = (1-w1) * self.srtt_ms + w1 * sample_ms
 
-
-
     def _print_metrics_summary(self):
         now = time.time()
         dur = max(1e-6, now - self._start_time)
@@ -156,7 +154,15 @@ class GameClientProtocol:
 
         self.metrics["reliable"]["tx"] += 1
         self.metrics["reliable"]["bytes_tx"] += len(critical_state)
-        self._inflight[seq] = time.time()
+
+        now_ms = int(time.time() * 1000)
+        self._inflight[seq] = Inflight(
+            payload_bytes=critical_state,
+            ctrl_stream_id=self.ctrl_stream_id,
+            seq=seq,
+            ts_first_ms=now_ms,
+            ts_last_ms=now_ms,
+        )
 
         self.quic.send_stream_data(self.ctrl_stream_id, critical_state, end_stream=False)
         self.endpoint.transmit()

--- a/server.py
+++ b/server.py
@@ -177,9 +177,37 @@ class GameServer(QuicConnectionProtocol):
                         m_r["owl"].add(owl_ms)
                         m_r["jitter"].add(owl_ms)
 
+
+                        """
+                        ### -- TESTING RETRANSMISSION SCHEDULER --
+                        ### DROPPING + DELAYING ACKS
+                        DROP_EVERY = 7
+                        DELAY_MS = 400
+                        DELAY_MOD = 3
+
+                        seqn = self.next_expected_seq
+                        if DROP_EVERY and (seqn % DROP_EVERY == 0):
+                            print(f"[server][TEST] dropping ACK for Seq={seqn}")
+                        else:
+                            if DELAY_MS and DELAY_MOD and (seqn % DELAY_MOD == 0):
+                                print(f"[server][TEST] delaying ACK {DELAY_MS}ms for Seq={seqn}")
+                                await asyncio.sleep(DELAY_MS / 1000.0)
+
+                            self._quic.send_stream_data(
+                                self._quic.get_next_available_stream_id(is_unidirectional=False),
+                                b"ack:" + data_bytes,
+                                end_stream=False
+                            )
+                            self.transmit()
+                        #END OF RETRANSMISSION TEST
+                        """
+
+                        ##COMMENT OUT THE REST OF THE BLOCK WHEN TESTING RETRANSMISSION
+
                         # Echo ACK for RTT calculation on client side
                         self._quic.send_stream_data(self._quic.get_next_available_stream_id(is_unidirectional=False), b"ack:" + data_bytes, end_stream=False)
                         self.transmit()
+
 
                     except Exception as e:
                         print(f"[server] Error processing reliable packet: {e}")


### PR DESCRIPTION
- Added `retransmit_scheduler()` task to periodically scan inflight reliable packets and resend unacknowledged ones after a calculated RTO.
- Implemented smoothed **RTT** *(srtt)* and **RTT** variance *(rttvar)* estimators to dynamically adjust the retransmission timeout.
- Introduced Inflight tracking structure to record per-packet send timestamps, retries, and stream IDs.
- Added automatic packet dropping after **MAX_RETRIES** retries to prevent indefinite retransmission loops.
- On the server side, integrated sequence buffering and timeout-based skipping for delayed or missing reliable packets.
- Introduced a retransmission test to simulate delayed or dropped ACKs for validation of retransmission logic.

## Sample Output
### Server
```
[server] 🔄 [Reliable] RX: Seq=28, current expected=42
[server] ⏩ [Unreliable] RX: Seq=268, OWL=0.33ms, Data=pos:-7.96,-6.76
[server] [Reliable] RX: Unsequenced data: b'{"type":"state_update","channel":0,"seq":42,...}'
[server] ✅ RELIABLE RX: Seq=42, OWL=0.38ms, Data={'player_id': 1, 'score': 81}
[server][TEST] dropping ACK for Seq=42
[server] ⏳ [Reliable] RX: Seq=43 (O.O.O), Expected=42. Buffering...
[server] ⚠️ RELIABLE SKIP: Seq=42 skipped. Next Seq=43 waited for 205.4ms > 200ms.

```
### Client
```
[client] [Reliable] SENT: Seq=42, Size=114, TS=1762364386.6679
[client] Retransmit seq=28 (try 4)
[client] Retransmit seq=35 (try 2)
[client] [Reliable] ACK RX: AppSeq=43, RTT=403.5ms
[client] Drop seq=21 after 5 retries

```
